### PR TITLE
#9: Publish native binaries with each release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
   binary:
     name: ${{ matrix.os }} native binary
     needs: [jar]
+    # only build binaries for releases
+    if: github.event_name == 'workflow_dispatch' 
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
     - name: Test
       run: make test
 
-  package:
+  jar:
     # ydoc.jar built on linux github runners encountered the following error with JShell:
     # "java.lang.NullPointerException: Cannot invoke "com.sun.tools.javac.code.Scope$StarImportScope.isFilled()" because "tree.starImportScope" is null"
     # (reproduced on 31/07/2024 within image etc/Dockerfile.dev)
-    # therefore, we use a windows runner to build the jar and execute doc check tasks
+    # therefore, we use a windows runner to build the jar
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
           apps: cs scala3 scalafmt
           jvm: graalvm-java21:21.0.2
 
-      - name: Package
+      - name: Build Jar
         run: make usage/ydoc.jar
   
       - uses: actions/upload-artifact@v4
@@ -60,7 +60,7 @@ jobs:
   
   binary:
     name: ${{ matrix.os }} native binary
-    needs: [package]
+    needs: [jar]
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
@@ -96,7 +96,7 @@ jobs:
 
   doc-check:
     runs-on: ubuntu-latest
-    needs: [package]
+    needs: [jar]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -123,7 +123,7 @@ jobs:
   
   release:
     runs-on: ubuntu-latest
-    needs: [test, package, binary, doc-check]
+    needs: [test, jar, binary, doc-check]
     if: github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,42 @@ jobs:
           path: usage/ydoc.jar
           if-no-files-found: error
           retention-days: 1
+  
+  binary:
+    name: ${{ matrix.os }} native binary
+    needs: [package]
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu, windows]
+        include:
+          - os: windows
+            name: windows
+          - os: ubuntu
+            name: linux
+    steps:
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ydoc.jar
+          path: usage/
+
+      - name: Build native binary from jar
+        run: native-image -jar usage/ydoc.jar ydoc-${{ matrix.name }}
+      
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ydoc-${{ matrix.name }}
+          path: ydoc-${{ matrix.name }}*
+          if-no-files-found: error
+          retention-days: 1
 
   doc-check:
     runs-on: ubuntu-latest
@@ -87,13 +123,23 @@ jobs:
   
   release:
     runs-on: ubuntu-latest
-    needs: [test, package, doc-check]
+    needs: [test, package, binary, doc-check]
     if: github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/download-artifact@v4
       with:
         name: ydoc.jar
         path: usage/
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: ydoc-linux
+        path: bin/
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: ydoc-windows
+        path: bin/
 
     - name: Release
       uses: softprops/action-gh-release@v2
@@ -105,3 +151,5 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
           usage/ydoc.jar
+          bin/ydoc-linux
+          bin/ydoc-windows.exe

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Inspired by [cram](https://bitheap.org/cram/), [knit](https://github.com/Kotlin/kotlinx-knit), [mdoc](https://github.com/scalameta/mdoc), [mdx](https://github.com/realworldocaml/mdx)
 
 ## Motivation
-Documenting code is a an effort, maintening the documentation can be even harder. This is especially true for code snippets that can 'rot' easily with refactorings, API changes, renaming, removals...
+Documenting code is a an effort, maintaining the documentation can be even harder. This is especially true for code snippets that can 'rot' easily with refactorings, API changes, renaming, removals...
 
 But code snippets also have considerable values, as a few lines of codes can sometimes illustrate an API usage in a much more consise and expressive way than a higher level description. 
  
@@ -229,7 +229,13 @@ Run `make usage/ydoc.jar` to produce the executable jar `ydoc.jar` in `usage/`
 
 ### From the release jar
 
-Each [github release](https://github.com/NyuB/yadladoc/releases/) contains an executable jar, which is enough to run all of the examples listed in this document. 
+Each [github release](https://github.com/NyuB/yadladoc/releases/) contains an executable `ydoc.jar`, which is enough to run all of the examples listed in this document.
+
+### From the release binary
+
+Each [github release](https://github.com/NyuB/yadladoc/releases/) contains native binaries for windows and linux.
+
+**NB** these binaries do not currently support the [in-place decoration feature](#in-place-snippet-decoration), decorated snippets will be ignored.
 
 ## Contribute
 


### PR DESCRIPTION
Resolves #9

Should add other way than SPI to load built-ins decorators, since they are currently unavailable with these binaries