### PR TITLE
Load cram decorator without SPI to allow future native binaries to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ list.get(-1)
 
 #### Custom decorators
 
-Decorators are discovered using the java Service Provider Interface mechanism. To make your own decorator available, simply add your jar with your implementation of ScriptDecoratorService
+Decorators are discovered using the java Service Provider Interface mechanism. To make your own decorator available, implement ScriptDecoratorService:
 
 ```scala ydoc.example=interpreter/src/nyub/interpreter/ScriptDecoratorService.scala ydoc.template=raw
 package nyub.interpreter
@@ -213,6 +213,12 @@ trait ScriptDecoratorService:
       */
     def createDecorator(parameters: Map[String, String]): ScriptDecorator
 
+```
+
+Then add the jar with your implementation to the classpath when running yadladoc:
+
+```console
+$ java -cp my-decorators.jar -jar ydoc.jar check README.md 
 ```
 
 You can then refer to your decorator using the ```id``` method return value as ```ydoc.decorator``` value.

--- a/yadladoc/src/nyub/yadladoc/Configuration.scala
+++ b/yadladoc/src/nyub/yadladoc/Configuration.scala
@@ -13,18 +13,12 @@ val DEFAULT_LANGUAGE = Language.named("default")
 trait Configuration:
     def properties: Properties
     def configDir: Path
+    def constants: ConfigurationConstants
+
     def includesDir: Path =
-        properties.getPathOrDefault("ydoc.includesDir")(configDir / "includes")
-
-    def snippetInjectionKey: String = "ydoc.snippet"
-
-    def exampleNameInjectionKey: String = "ydoc.exampleName"
-
-    def subExampleNameInjectionKey: String = "ydoc.subExampleName"
-
-    def exampleNamePropertyKey: String = "ydoc.example"
-
-    def decoratorIdPropertyKey: String = "ydoc.decorator"
+        properties.getPathOrDefault(constants.includeDirPropertyKey)(
+          configDir / "includes"
+        )
 
     def templateFile(templateId: TemplateId): Path =
         includesDir / s"${templateId}.template"
@@ -33,25 +27,29 @@ trait Configuration:
         language: Option[Language],
         properties: Properties
     ): TemplateId =
-        val id = properties.getOrDefault("ydoc.template")(
+        val id = properties.getOrDefault(constants.templateIdPropertyKey)(
           language.getOrElse(DEFAULT_LANGUAGE).name
         )
         TemplateId(id)
 
     def templateInjectionPrefix =
-        properties.getOrDefault("ydoc.templateInjectionPrefix")("${{")
+        properties.getOrDefault(
+          constants.templateConstants.injectionPrefixPropertyKey
+        )(constants.templateConstants.defaultInjectionPrefix)
 
     def templateInjectionPostfix =
-        properties.getOrDefault("ydoc.templateInjectionPostfix")("}}")
+        properties.getOrDefault(
+          constants.templateConstants.injectionSuffixPropertyKey
+        )(constants.templateConstants.defaultInjectionSuffix)
 
     def documentationKindForSnippet(snippet: Snippet): DocumentationKind =
         snippet.properties
-            .get(exampleNamePropertyKey)
+            .get(constants.exampleNamePropertyKey)
             .filterNot(_.isBlank)
             .map(DocumentationKind.ExampleSnippet(_, snippet))
             .getOrElse:
                 snippet.properties
-                    .get(decoratorIdPropertyKey)
+                    .get(constants.decoratorIdPropertyKey)
                     .filterNot(_.isBlank)
                     .map(DocumentationKind.DecoratedSnippet(_))
                     .getOrElse(DocumentationKind.Raw)
@@ -67,12 +65,18 @@ trait Configuration:
     def prefixTemplateIds(
         snippet: Snippet
     ): Iterable[TemplateId] =
-        snippet.properties.get("ydoc.prefix").toList.map(TemplateId(_))
+        snippet.properties
+            .get(constants.templateConstants.prefixTemplatePropertyKey)
+            .toList
+            .map(TemplateId(_))
 
     def suffixTemplateIds(
         snippet: Snippet
     ): Iterable[TemplateId] =
-        snippet.properties.get("ydoc.suffix").toList.map(TemplateId(_))
+        snippet.properties
+            .get(constants.templateConstants.suffixTemplatePropertyKey)
+            .toList
+            .map(TemplateId(_))
 
     def scriptDecorator(
         decoratorId: String,
@@ -94,8 +98,99 @@ trait Configuration:
             .forEach(s => mutableMap(s.id) = s)
         mutableMap.toMap
 
+/** Constants meant to be overridable for programatic use (i.e. as a library) of
+  * yadladoc
+  *
+  * For user-provided constants use [[nyub.yadladocProperties]]
+  */
+trait ConfigurationConstants:
+    def snippetInjectionKey: String
+
+    def exampleNameInjectionKey: String
+
+    def subExampleNameInjectionKey: String
+
+    def exampleNamePropertyKey: String
+
+    def decoratorIdPropertyKey: String
+
+    def templateIdPropertyKey: String
+
+    def includeDirPropertyKey: String
+
+    def templateConstants: TemplateConstants
+
+    /** Constants related to yadladoc's templating features
+      */
+    trait TemplateConstants:
+        /** @return
+          *   the property to look for in an example properties when searching a
+          *   for the template to insert before this example
+          */
+        def prefixTemplatePropertyKey: String
+
+        /** @return
+          *   the property to look for in an example properties when searching a
+          *   for the template to insert after this example
+          */
+        def suffixTemplatePropertyKey: String
+
+        /** @return
+          *   the character sequence marking the start of an injection key in a
+          *   template
+          */
+        def injectionPrefixPropertyKey: String
+
+        /** @return
+          *   the character sequence marking the end of an injection key in a
+          *   template
+          */
+        def injectionSuffixPropertyKey: String
+
+        /** @return
+          *   the default character sequence to use when
+          *   [[TemplateConstants#injectionPrefixPropertyKey]] is not found
+          */
+        def defaultInjectionPrefix: String
+
+        /** @return
+          *   the default character sequence to use when
+          *   [[TemplateConstants#injectionSuffixPropertyKey]] is not found
+          */
+        def defaultInjectionSuffix: String
+
+object ConfigurationConstants:
+    object DEFAULTS extends ConfigurationConstants:
+        override val snippetInjectionKey: String = "ydoc.snippet"
+
+        override val exampleNameInjectionKey: String = "ydoc.exampleName"
+
+        override val subExampleNameInjectionKey: String = "ydoc.subExampleName"
+
+        override val exampleNamePropertyKey: String = "ydoc.example"
+
+        override val decoratorIdPropertyKey: String = "ydoc.decorator"
+
+        override val templateIdPropertyKey: String = "ydoc.template"
+
+        override val includeDirPropertyKey: String = "ydoc.includeDir"
+
+        override val templateConstants: TemplateConstants = new:
+            override val prefixTemplatePropertyKey: String = "ydoc.prefix"
+            override val suffixTemplatePropertyKey: String = "ydoc.suffix"
+
+            override val injectionPrefixPropertyKey: String =
+                "ydoc.templateInjectionPrefix"
+
+            override val injectionSuffixPropertyKey: String =
+                "ydoc.templateInjectionPostfix"
+
+            override val defaultInjectionPrefix: String = "${{"
+            override val defaultInjectionSuffix: String = "}}"
+
 case class ConfigurationFromFile(
     override val configDir: Path,
+    override val constants: ConfigurationConstants,
     private val storage: FileSystem = OsFileSystem()
 ) extends Configuration:
     override val properties: Properties =

--- a/yadladoc/src/nyub/yadladoc/Configuration.scala
+++ b/yadladoc/src/nyub/yadladoc/Configuration.scala
@@ -8,6 +8,7 @@ import nyub.filesystem.OsFileSystem
 import nyub.interpreter.ScriptDecoratorService
 import java.util.ServiceLoader
 import nyub.interpreter.ScriptDecorator
+import nyub.interpreter.CramDecoratorService
 
 val DEFAULT_LANGUAGE = Language.named("default")
 trait Configuration:
@@ -90,13 +91,28 @@ trait Configuration:
               )
             )
 
-    def decoratorServices: Map[String, ScriptDecoratorService] =
+    final def decoratorServices: Map[String, ScriptDecoratorService] =
         val mutableMap =
-            scala.collection.mutable.Map.empty[String, ScriptDecoratorService]
+            scala.collection.mutable.Map.from(builtinDecoratorServices)
         ServiceLoader
             .load(classOf[ScriptDecoratorService])
             .forEach(s => mutableMap(s.id) = s)
         mutableMap.toMap
+
+    /** **Please note**: this method should only return decorator services meant
+      * to be usable within any user environment
+      *
+      *   - Do not add any JVM reflective feature as yadladoc could be packaged
+      *     as native binaries
+      *   - Do not add any OS specific feature as yadladoc supports both Unix
+      *     and Windows
+      *
+      * For more specific or user-defined decorators, use SPI embedded in the
+      * classpath
+      * @return
+      */
+    def builtinDecoratorServices: Map[String, ScriptDecoratorService] =
+        Map("cram" -> CramDecoratorService())
 
 /** Constants meant to be overridable for programatic use (i.e. as a library) of
   * yadladoc

--- a/yadladoc/src/nyub/yadladoc/Yadladoc.scala
+++ b/yadladoc/src/nyub/yadladoc/Yadladoc.scala
@@ -89,9 +89,9 @@ class Yadladoc(
         example.build(
           templating,
           id => config.templateFile(id).useLines(_.toList),
-          config.snippetInjectionKey,
-          config.exampleNameInjectionKey,
-          config.subExampleNameInjectionKey,
+          config.constants.snippetInjectionKey,
+          config.constants.exampleNameInjectionKey,
+          config.constants.subExampleNameInjectionKey,
           config.properties.toMap
         )
 

--- a/yadladoc/test/src/nyub/yadladoc/ConfigurationSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/ConfigurationSuite.scala
@@ -21,4 +21,6 @@ class ConfigurationSuite extends munit.FunSuite with AssertExtensions:
         override val configDir = Files.createTempDirectory("test")
         override val properties = Properties.ofMap(Map.empty)
 
+        override val constants = ConfigurationConstants.DEFAULTS
+
 end ConfigurationSuite

--- a/yadladoc/test/src/nyub/yadladoc/YadladocSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/YadladocSuite.scala
@@ -20,7 +20,7 @@ class YadladocSuite
             ```
             """
 
-        Yadladoc(ConfigurationFromFile(configDir))
+        Yadladoc(testConfig(configDir))
             .run(outputDir, markdownFile)
 
         outputDir.resolve("one.java") `has content` l"""
@@ -48,7 +48,7 @@ class YadladocSuite
             """
 
             val Results(generatedFiles, errors) =
-                Yadladoc(ConfigurationFromFile(configDir))
+                Yadladoc(testConfig(configDir))
                     .run(outputDir, markdownFile)
 
             errors `is equal to` List.empty
@@ -91,7 +91,7 @@ class YadladocSuite
             new AwesomeClass().doAmazingStuff(); // Wunderbar !
             ```
             """
-            Yadladoc(ConfigurationFromFile(configDir))
+            Yadladoc(testConfig(configDir))
                 .run(outputDir, markdownFile)
 
             outputDir.resolve("surround.java") `has content` l"""
@@ -109,7 +109,7 @@ class YadladocSuite
                 - A simple
                     * Markdown
             """
-            Yadladoc(ConfigurationFromFile(configDir))
+            Yadladoc(testConfig(configDir))
                 .check(outputDir, markdownFile) `is equal to` Results(
               Seq.empty,
               Seq.empty
@@ -130,7 +130,7 @@ class YadladocSuite
             println("Hello world");
             """
 
-        Yadladoc(ConfigurationFromFile(configDir))
+        Yadladoc(testConfig(configDir))
             .check(outputDir, markdownFile) matches:
             case Results(
                   Seq(GeneratedFile(Some(_), _, generatedFrom)),
@@ -149,7 +149,7 @@ class YadladocSuite
             """
         makeFile(outputDir, "notTheOneYouExpected.java", "Some content")
 
-        Yadladoc(ConfigurationFromFile(configDir))
+        Yadladoc(testConfig(configDir))
             .check(
               outputDir,
               markdownFile
@@ -171,7 +171,7 @@ class YadladocSuite
               "txt.template",
               "${{ydoc.exampleName}}"
             )
-            Yadladoc(ConfigurationFromFile(configDir))
+            Yadladoc(testConfig(configDir))
                 .run(outputDir, markdownFile)
 
             outputDir.resolve("a/b.txt") `has content` "a_b_txt"
@@ -197,7 +197,7 @@ class YadladocSuite
               "B.template",
               "// ${{ydoc.subExampleName}}"
             )
-            Yadladoc(ConfigurationFromFile(configDir))
+            Yadladoc(testConfig(configDir))
                 .run(outputDir, markdownFile)
 
             outputDir.resolve("javaExample.java") `has content` l"""
@@ -221,7 +221,7 @@ class YadladocSuite
               "custom.template",
               "class Custom { ${{ydoc.snippet}} }"
             )
-            Yadladoc(ConfigurationFromFile(configDir))
+            Yadladoc(testConfig(configDir))
                 .run(outputDir, markdownFile)
 
             outputDir.resolve(
@@ -236,7 +236,7 @@ class YadladocSuite
                 java.util.List.of(1,2,3)
                 ```
                 """
-            Yadladoc(ConfigurationFromFile(configDir))
+            Yadladoc(testConfig(configDir))
                 .run(outputDir, markdownFile)
             markdownFile `has content` l"""
             ```java ydoc.decorator=jshell
@@ -253,14 +253,16 @@ class YadladocSuite
                 java.util.List.of(1,2,3)
                 ```
                 """
-            Yadladoc(ConfigurationFromFile(configDir))
+            Yadladoc(testConfig(configDir))
                 .check(outputDir, markdownFile)
                 .errors
                 .toList matches:
                 case List(CheckErrors.MismatchingContent(f, _, _)) =>
                     markdownFile `is equal to` f
 
-    def testWithinYDocContext(name: String)(f: (Path, Path, Path) => Any) =
+    private def testWithinYDocContext(name: String)(
+        f: (Path, Path, Path) => Any
+    ) =
         val withYdocContext =
             FunFixture.map3(withTempDir, withTempDir, withTempDir)
         withYdocContext.test(name): (outputDir, configDir, workingDir) =>
@@ -278,7 +280,10 @@ class YadladocSuite
             )
             f(outputDir, configDir, workingDir)
 
-    object TestContext:
+    private def testConfig(configDir: Path): Configuration =
+        ConfigurationFromFile(configDir, ConfigurationConstants.DEFAULTS)
+
+    private object TestContext:
         val kotlinTemplate = l"""
             package com.example
             fun main() {

--- a/yadladoc_app/src/nyub/yadladoc/app/Main.scala
+++ b/yadladoc_app/src/nyub/yadladoc/app/Main.scala
@@ -6,6 +6,7 @@ import nyub.yadladoc.Results
 import nyub.yadladoc.Yadladoc
 import java.nio.file.Paths
 import nyub.yadladoc.Errors
+import nyub.yadladoc.ConfigurationConstants
 
 private val OK_RETURN_CODE = 0
 private val INVALID_ARGUMENT_RETURN_CODE = 1
@@ -39,7 +40,9 @@ private val DOCUMENTATION_PROBLEM_RETURN_CODE = 2
         System.exit(INVALID_ARGUMENT_RETURN_CODE)
 
     val outputDir = Paths.get(".")
-    val yadladoc = Yadladoc(ConfigurationFromFile(configDir))
+    val yadladoc = Yadladoc(
+      ConfigurationFromFile(configDir, ConfigurationConstants.DEFAULTS)
+    )
     val printer = AnsiPrinter.NO_COLOR
     if command == "run" then
         val Results(generated, errors) = yadladoc.run(outputDir, markdownFile)


### PR DESCRIPTION
Related to #9

Currently, decorators are only discovered via SPI. This java featur relies on reflection and JVM dynamism and will not be available in native binaries. Since the cram decorator does not rely on any JVM specific feature, load it outside SPI to allow every packaging of ydladoc to use it.