### PR TITLE
Testability improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 dev: fmt test
 
 test:
-	$(MILLW) assert_extensions.test + filesystem.test + interpreter.test + yadladoc.test + yadladoc_app.compile
+	$(MILLW) -j 4 assert_extensions.test + filesystem.test + interpreter.test + yadladoc.test + yadladoc_app.compile
 
 usage-test: $(YDOC_JAR)
 	$(MAKE) -C usage test

--- a/yadladoc/src/nyub/yadladoc/Configuration.scala
+++ b/yadladoc/src/nyub/yadladoc/Configuration.scala
@@ -44,16 +44,23 @@ trait Configuration:
         )(constants.templateConstants.defaultInjectionSuffix)
 
     def documentationKindForSnippet(snippet: Snippet): DocumentationKind =
-        snippet.properties
-            .get(constants.exampleNamePropertyKey)
-            .filterNot(_.isBlank)
-            .map(DocumentationKind.ExampleSnippet(_, snippet))
-            .getOrElse:
-                snippet.properties
-                    .get(constants.decoratorIdPropertyKey)
-                    .filterNot(_.isBlank)
-                    .map(DocumentationKind.DecoratedSnippet(_))
-                    .getOrElse(DocumentationKind.Raw)
+        exampleKind(snippet)
+            .orElse(decoratedKind(snippet))
+            .getOrElse(DocumentationKind.Raw)
+
+    private def exampleKind(
+        snippet: Snippet
+    ): Option[DocumentationKind.ExampleSnippet] = snippet.properties
+        .get(constants.exampleNamePropertyKey)
+        .filterNot(_.isBlank)
+        .map(DocumentationKind.ExampleSnippet(_, snippet))
+
+    private def decoratedKind(
+        snippet: Snippet
+    ): Option[DocumentationKind.DecoratedSnippet] = snippet.properties
+        .get(constants.decoratorIdPropertyKey)
+        .filterNot(_.isBlank)
+        .map(DocumentationKind.DecoratedSnippet(_))
 
     def exampleFile(
         exampleName: String,

--- a/yadladoc/src/nyub/yadladoc/DocumentationGeneration.scala
+++ b/yadladoc/src/nyub/yadladoc/DocumentationGeneration.scala
@@ -15,15 +15,7 @@ private class DocumentationGeneration(
           exampleSnippets.accumulate(exampleSnippet)
         )
 
-    def addRawSnippet(
-        markdownSnippet: Markdown.Snippet
-    ): DocumentationGeneration =
-        DocumentationGeneration(
-          markdownDecoration.accumulate(markdownSnippet),
-          exampleSnippets
-        )
-
-    def addRawBlock(markdownRaw: Markdown.Raw): DocumentationGeneration =
+    def addRawBlock(markdownRaw: Markdown.Block): DocumentationGeneration =
         DocumentationGeneration(
           markdownDecoration.accumulate(markdownRaw),
           exampleSnippets

--- a/yadladoc/src/nyub/yadladoc/DocumentationGeneration.scala
+++ b/yadladoc/src/nyub/yadladoc/DocumentationGeneration.scala
@@ -52,13 +52,10 @@ private class ExampleSnippetMerger(
     def accumulate(
         exampleSnippet: DocumentationKind.ExampleSnippet
     ): ExampleSnippetMerger =
+        val example = makeExample(exampleSnippet)
         val updatedExamples = examples.updatedWith(exampleSnippet.name):
-            case None =>
-                Some(
-                  makeExample(exampleSnippet)
-                )
-            case Some(previous) =>
-                Some(previous.merge(makeExample(exampleSnippet)))
+            case None           => Some(example)
+            case Some(previous) => Some(previous.merge(example))
         ExampleSnippetMerger(config, updatedExamples)
 
     private def makeExample(

--- a/yadladoc/src/nyub/yadladoc/Example.scala
+++ b/yadladoc/src/nyub/yadladoc/Example.scala
@@ -1,7 +1,5 @@
 package nyub.yadladoc
 
-import nyub.templating.TemplateInjection
-
 case class Example(
     val name: String,
     val template: TemplateId,
@@ -19,41 +17,6 @@ case class Example(
           language,
           content ++ other.content
         )
-
-    def build(
-        templating: TemplateInjection,
-        getTemplate: TemplateId => Iterable[String],
-        bodyInjectionKey: String,
-        exampleNameInjectionKey: String,
-        partNameInjectionKey: String,
-        additionalInjections: Map[String, String]
-    ): Iterable[String] =
-        val injectionProperties: Map[String, String] = additionalInjections
-            .updated(exampleNameInjectionKey, sanitizedName(name))
-        val all = content.zipWithIndex.flatMap: (c, i) =>
-
-            val partProperties = injectionProperties.updated(
-              partNameInjectionKey,
-              sanitizedName(name + "_" + i)
-            )
-            val prefixLines = c.prefixTemplateIds
-                .flatMap(getTemplate)
-                .map(templating.inject(_, partProperties))
-
-            val suffixLines = c.suffixTemplateIds
-                .flatMap(getTemplate)
-                .map(templating.inject(_, partProperties))
-
-            prefixLines ++ c.body ++ suffixLines
-
-        templating.inject(
-          getTemplate(template),
-          injectionProperties
-              .updated(bodyInjectionKey, all.mkString("\n"))
-        )
-
-    private def sanitizedName(exampleName: String): String =
-        exampleName.replaceAll("[/\\:.]+", "_")
 
 case class ExampleContent(
     prefixTemplateIds: Iterable[TemplateId],

--- a/yadladoc/src/nyub/yadladoc/ExampleAssembler.scala
+++ b/yadladoc/src/nyub/yadladoc/ExampleAssembler.scala
@@ -1,0 +1,41 @@
+package nyub.yadladoc
+
+import nyub.templating.TemplateInjection
+
+class ExampleAssembler(
+    private val templating: TemplateInjection,
+    private val getTemplate: TemplateId => Iterable[String],
+    private val bodyInjectionKey: String,
+    private val exampleNameInjectionKey: String,
+    private val partNameInjectionKey: String,
+    private val additionalInjections: Map[String, String]
+):
+    def assemble(
+        example: Example
+    ): Iterable[String] =
+        val injectionProperties: Map[String, String] = additionalInjections
+            .updated(exampleNameInjectionKey, sanitizedName(example.name))
+        val all = example.content.zipWithIndex.flatMap: (c, i) =>
+
+            val partProperties = injectionProperties.updated(
+              partNameInjectionKey,
+              sanitizedName(example.name + "_" + i)
+            )
+            val prefixLines = c.prefixTemplateIds
+                .flatMap(getTemplate)
+                .map(templating.inject(_, partProperties))
+
+            val suffixLines = c.suffixTemplateIds
+                .flatMap(getTemplate)
+                .map(templating.inject(_, partProperties))
+
+            prefixLines ++ c.body ++ suffixLines
+
+        templating.inject(
+          getTemplate(example.template),
+          injectionProperties
+              .updated(bodyInjectionKey, all.mkString("\n"))
+        )
+
+    private def sanitizedName(exampleName: String): String =
+        exampleName.replaceAll("[/\\:.]+", "_")

--- a/yadladoc/src/nyub/yadladoc/Yadladoc.scala
+++ b/yadladoc/src/nyub/yadladoc/Yadladoc.scala
@@ -120,7 +120,7 @@ class Yadladoc(
                             )
                         case DocumentationKind.Raw =>
                             docResults.map(
-                              _.addRawSnippet(snippet)
+                              _.addRawBlock(snippet)
                             ) // no doc to generate
                 case raw: Markdown.Raw =>
                     docResults.map(_.addRawBlock(raw)) // no doc to generate
@@ -187,7 +187,7 @@ class Yadladoc(
             decorated
                 .map(d =>
                     docResults.map(
-                      _.addRawSnippet(
+                      _.addRawBlock(
                         Markdown.Snippet(
                           snippet.header,
                           d.toSeq
@@ -200,5 +200,5 @@ class Yadladoc(
                       .withError(
                         MissingDecoratorError(decoratorId)
                       )
-                      .map(_.addRawSnippet(snippet))
+                      .map(_.addRawBlock(snippet))
                 )

--- a/yadladoc/src/nyub/yadladoc/Yadladoc.scala
+++ b/yadladoc/src/nyub/yadladoc/Yadladoc.scala
@@ -22,6 +22,15 @@ class Yadladoc(
       config.templateInjectionPostfix
     )
 
+    private val exampleAssembler = ExampleAssembler(
+      templating,
+      id => config.templateFile(id).useLines(_.toList),
+      config.constants.snippetInjectionKey,
+      config.constants.exampleNameInjectionKey,
+      config.constants.subExampleNameInjectionKey,
+      config.properties.toMap
+    )
+
     def run(outputDir: Path, markdownFile: Path): Results[Seq[GeneratedFile]] =
         run(outputDir, markdownFile, fileSystem)
 
@@ -53,7 +62,7 @@ class Yadladoc(
             .flatMap: examples =>
                 val generated =
                     for example <- examples yield
-                        val fullExample = buildFullExample(example)
+                        val fullExample = exampleAssembler.assemble(example)
                         val exampleFile =
                             config.exampleFile(example.name, example.language)
 
@@ -84,16 +93,6 @@ class Yadladoc(
 
         generatedExamples.merge(generatedMarkdown): (examples, markdown) =>
             Results.success(examples.toSeq ++ markdown.toList)
-
-    private def buildFullExample(example: Example) =
-        example.build(
-          templating,
-          id => config.templateFile(id).useLines(_.toList),
-          config.constants.snippetInjectionKey,
-          config.constants.exampleNameInjectionKey,
-          config.constants.subExampleNameInjectionKey,
-          config.properties.toMap
-        )
 
     private def dogGenFromMarkdown(
         markdown: Iterable[Markdown.Block]

--- a/yadladoc/test/src/nyub/yadladoc/ConfigurationSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/ConfigurationSuite.scala
@@ -6,7 +6,30 @@ import nyub.interpreter.CramDecoratorService
 import nyub.interpreter.JShellDecoratorService
 
 class ConfigurationSuite extends munit.FunSuite with AssertExtensions:
-    test("built-in services"):
+    test("Documentation kind is example when ydoc.example property is present"):
+        TestConfig.documentationKindForSnippet(
+          Snippet(None, Seq.empty, Properties("ydoc.example" -> "A"))
+        ) matches:
+            case DocumentationKind.ExampleSnippet("A", _) => ()
+
+    test(
+      "Documentation kind is decorated when ydoc.decorator property is present"
+    ):
+        TestConfig.documentationKindForSnippet(
+          Snippet(
+            None,
+            Seq.empty,
+            Properties("ydoc.decorator" -> "decoratorId")
+          )
+        ) `is equal to`
+            DocumentationKind.DecoratedSnippet("decoratorId")
+
+    test("Documentation kind is raw when no special property is present"):
+        TestConfig.documentationKindForSnippet(
+          Snippet(None, Seq.empty, Properties())
+        ) `is equal to` DocumentationKind.Raw
+
+    test("Built-in services"):
         TestConfig.decoratorServices
             .get("cram")
             .map(_.getClass()) `is equal to some` classOf[CramDecoratorService]

--- a/yadladoc/test/src/nyub/yadladoc/ConfigurationSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/ConfigurationSuite.scala
@@ -29,6 +29,44 @@ class ConfigurationSuite extends munit.FunSuite with AssertExtensions:
           Snippet(None, Seq.empty, Properties())
         ) `is equal to` DocumentationKind.Raw
 
+    test("Templates are searched in includes dir and suffixed by '.template'"):
+        TestConfig.templateFile(
+          TemplateId("id")
+        ) `is equal to` TestConfig.configDir
+            .resolve("includes")
+            .resolve("id.template")
+
+    test(
+      "Given no language and no template property, default template is used"
+    ):
+        TestConfig.templateId(None, Properties.empty) `is equal to` TemplateId(
+          "default"
+        )
+
+    test(
+      "Given a language and no template property, language name is used as template id"
+    ):
+        TestConfig.templateId(
+          Some(Language.named("scala")),
+          Properties.empty
+        ) `is equal to` TemplateId("scala")
+
+    test(
+      "Given a language and a template property, the property is used as template id"
+    ):
+        TestConfig.templateId(
+          Some(Language.named("scala")),
+          Properties(TestConfig.constants.templateIdPropertyKey -> "prop")
+        ) `is equal to` TemplateId("prop")
+
+    test(
+      "Given no language and a template property, the property is used as template id"
+    ):
+        TestConfig.templateId(
+          None,
+          Properties(TestConfig.constants.templateIdPropertyKey -> "prop")
+        ) `is equal to` TemplateId("prop")
+
     test("Built-in services"):
         TestConfig.decoratorServices
             .get("cram")

--- a/yadladoc/test/src/nyub/yadladoc/DocumentationGenerationSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/DocumentationGenerationSuite.scala
@@ -1,0 +1,131 @@
+package nyub.yadladoc
+
+import nyub.assert.AssertExtensions
+import nyub.markdown.Markdown
+import java.nio.file.Paths
+import nyub.markdown.Markdown.Snippet.Header
+import nyub.markdown.Markdown.Snippet.Prefix
+
+class DocumentationGenerationSuite extends munit.FunSuite with AssertExtensions:
+    test("Three example snippets, first two in the same example"):
+        val firstSnippet: DocumentationKind.ExampleSnippet =
+            DocumentationKind.ExampleSnippet(
+              "A",
+              Snippet(someLanguage, Seq("a = 1"), Properties.empty)
+            )
+        val secondSnippet: DocumentationKind.ExampleSnippet =
+            DocumentationKind.ExampleSnippet(
+              "A",
+              Snippet(someLanguage, Seq("b = 1"), Properties.empty)
+            )
+        val thirdSnippet: DocumentationKind.ExampleSnippet =
+            DocumentationKind.ExampleSnippet(
+              "B",
+              Snippet(someLanguage, Seq("c = 1"), Properties.empty)
+            )
+
+        val docGen = DocumentationGeneration
+            .init(testConfig)
+            .addExampleSnippet(ignoredMdSnippet, firstSnippet)
+            .addExampleSnippet(ignoredMdSnippet, secondSnippet)
+            .addExampleSnippet(ignoredMdSnippet, thirdSnippet)
+
+        docGen.exampleSnippets.examples("A") `is equal to` Example(
+          "A",
+          TemplateId(someLanguage.get.name),
+          someLanguage,
+          Seq(
+            bodyOnlyExampleContent(firstSnippet.snippet.lines),
+            bodyOnlyExampleContent(secondSnippet.snippet.lines)
+          )
+        )
+
+    test("Include prefix when prefix property is present"):
+        val snippet: DocumentationKind.ExampleSnippet =
+            DocumentationKind.ExampleSnippet(
+              "A",
+              Snippet(
+                someLanguage,
+                Seq("a = 1"),
+                Properties("ydoc.prefix" -> "prefixId")
+              )
+            )
+        val docGen = DocumentationGeneration
+            .init(testConfig)
+            .addExampleSnippet(ignoredMdSnippet, snippet)
+        docGen.exampleSnippets
+            .examples("A")
+            .content
+            .singleElement
+            .prefixTemplateIds `is equal to` Seq(TemplateId("prefixId"))
+
+    test("Include suffix when suffix property is present"):
+        val snippet: DocumentationKind.ExampleSnippet =
+            DocumentationKind.ExampleSnippet(
+              "A",
+              Snippet(
+                someLanguage,
+                Seq("a = 1"),
+                Properties("ydoc.suffix" -> "suffixId")
+              )
+            )
+        val docGen = DocumentationGeneration
+            .init(testConfig)
+            .addExampleSnippet(ignoredMdSnippet, snippet)
+        docGen.exampleSnippets
+            .examples("A")
+            .content
+            .singleElement
+            .suffixTemplateIds `is equal to` Seq(TemplateId("suffixId"))
+
+    test("Markdown blocks are added as is"):
+        val docGen = DocumentationGeneration
+            .init(testConfig)
+            .addRawBlock(Markdown.Raw("# One line"))
+        docGen.markdownDecoration.decoratedLines `is equal to` Seq("# One line")
+
+    test("Markdown snippets are added along examples"):
+        val docGen = DocumentationGeneration
+            .init(testConfig)
+            .addExampleSnippet(
+              Markdown.Snippet(
+                Header(Prefix(3), someLanguage, " after language"),
+                Seq("a = 1")
+              ),
+              ignoredExampleSnippet
+            )
+        docGen.markdownDecoration.decoratedLines `is equal to` Seq(
+          s"```${someLanguage.get.name} after language",
+          "a = 1",
+          "```"
+        )
+
+    private def bodyOnlyExampleContent(
+        lines: Iterable[String]
+    ): ExampleContent = ExampleContent(Seq.empty, lines, Seq.empty)
+
+    private def ignoredMdSnippet: Markdown.Snippet = Markdown.Snippet(
+      Markdown.Snippet.Header(Markdown.Snippet.Prefix(3), None, ""),
+      Seq.empty
+    )
+
+    private def ignoredExampleSnippet: DocumentationKind.ExampleSnippet =
+        DocumentationKind.ExampleSnippet(
+          "A",
+          Snippet(someLanguage, Seq("a = 1"), Properties.empty)
+        )
+
+    private def testConfig: Configuration =
+        ConfigurationFromFile(Paths.get("."), ConfigurationConstants.DEFAULTS)
+
+    private val someLanguage = Some(Language.PYTHON)
+
+    extension [T](it: Iterable[T])
+        def singleElement: T =
+            val iterator = it.iterator
+            iterator.hasNext `is equal to` true
+            val res = iterator.next()
+            iterator.hasNext `is equal to` false
+            res
+
+end DocumentationGenerationSuite

--- a/yadladoc/test/src/nyub/yadladoc/ExampleAssemblerSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/ExampleAssemblerSuite.scala
@@ -3,37 +3,26 @@ package nyub.yadladoc
 import nyub.assert.AssertExtensions
 import nyub.templating.SurroundingTemplateInjection
 
-class ExampleSuite extends munit.FunSuite with AssertExtensions:
+class ExampleAssemblerSuite extends munit.FunSuite with AssertExtensions:
     test("Sanitized example name available in main template"):
-        Example(
+        val example = Example(
           "a/b.txt",
           templateId,
           None,
           Seq(
             bodyOnlyExampleContent("Line #1")
           )
-        ).build(
-          templateInjection,
-          getTemplate,
-          bodyInjectionKey,
-          exampleNameInjectionKey,
-          partNameInjectionKey,
-          Map.empty
-        ) `is equal to`
+        )
+
+        assembler.assemble(example) `is equal to`
             Seq("a_b_txt", "Line #1")
 
     test("Sanitized & indexed example name available in prefix template"):
         val contentWithPrefix =
             ExampleContent(Seq(prefixTemplateId), Seq("Body"), Seq.empty)
         val example = Example("a.txt", templateId, None, Seq(contentWithPrefix))
-        example.build(
-          templateInjection,
-          getTemplate,
-          bodyInjectionKey,
-          exampleNameInjectionKey,
-          partNameInjectionKey,
-          Map.empty
-        ) `is equal to` Seq(
+
+        assembler.assemble(example) `is equal to` Seq(
           "a_txt",
           "a_txt_0\nBody"
         )
@@ -42,17 +31,20 @@ class ExampleSuite extends munit.FunSuite with AssertExtensions:
         val contentWithPrefix =
             ExampleContent(Seq.empty, Seq("Body"), Seq(suffixTemplateId))
         val example = Example("a.txt", templateId, None, Seq(contentWithPrefix))
-        example.build(
-          templateInjection,
-          getTemplate,
-          bodyInjectionKey,
-          exampleNameInjectionKey,
-          partNameInjectionKey,
-          Map.empty
-        ) `is equal to` Seq(
+
+        assembler.assemble(example) `is equal to` Seq(
           "a_txt",
           "Body\na_txt_0"
         )
+
+    def assembler = ExampleAssembler(
+      templateInjection,
+      getTemplate,
+      bodyInjectionKey,
+      exampleNameInjectionKey,
+      partNameInjectionKey,
+      Map.empty
+    )
 
     private val exampleNameInjectionKey = "exampleNameInjectionKey"
     private val partNameInjectionKey = "partNameInjectionKey"
@@ -84,4 +76,4 @@ class ExampleSuite extends munit.FunSuite with AssertExtensions:
         lines: String*
     ): ExampleContent = ExampleContent(Seq.empty, lines, Seq.empty)
 
-end ExampleSuite
+end ExampleAssemblerSuite

--- a/yadladoc/test/src/nyub/yadladoc/ExampleSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/ExampleSuite.scala
@@ -1,0 +1,87 @@
+package nyub.yadladoc
+
+import nyub.assert.AssertExtensions
+import nyub.templating.SurroundingTemplateInjection
+
+class ExampleSuite extends munit.FunSuite with AssertExtensions:
+    test("Sanitized example name available in main template"):
+        Example(
+          "a/b.txt",
+          templateId,
+          None,
+          Seq(
+            bodyOnlyExampleContent("Line #1")
+          )
+        ).build(
+          templateInjection,
+          getTemplate,
+          bodyInjectionKey,
+          exampleNameInjectionKey,
+          partNameInjectionKey,
+          Map.empty
+        ) `is equal to`
+            Seq("a_b_txt", "Line #1")
+
+    test("Sanitized & indexed example name available in prefix template"):
+        val contentWithPrefix =
+            ExampleContent(Seq(prefixTemplateId), Seq("Body"), Seq.empty)
+        val example = Example("a.txt", templateId, None, Seq(contentWithPrefix))
+        example.build(
+          templateInjection,
+          getTemplate,
+          bodyInjectionKey,
+          exampleNameInjectionKey,
+          partNameInjectionKey,
+          Map.empty
+        ) `is equal to` Seq(
+          "a_txt",
+          "a_txt_0\nBody"
+        )
+
+    test("Sanitized & indexed example name available in suffix template"):
+        val contentWithPrefix =
+            ExampleContent(Seq.empty, Seq("Body"), Seq(suffixTemplateId))
+        val example = Example("a.txt", templateId, None, Seq(contentWithPrefix))
+        example.build(
+          templateInjection,
+          getTemplate,
+          bodyInjectionKey,
+          exampleNameInjectionKey,
+          partNameInjectionKey,
+          Map.empty
+        ) `is equal to` Seq(
+          "a_txt",
+          "Body\na_txt_0"
+        )
+
+    private val exampleNameInjectionKey = "exampleNameInjectionKey"
+    private val partNameInjectionKey = "partNameInjectionKey"
+    private val templateInjection = SurroundingTemplateInjection("<<", ">>")
+    private val bodyInjectionKey = "bodyInjectionKey"
+    private val testTemplate =
+        Seq(
+          s"<<$exampleNameInjectionKey>>",
+          s"<<$bodyInjectionKey>>"
+        )
+
+    private val testPrefixTemplate =
+        Seq(
+          s"<<$partNameInjectionKey>>"
+        )
+
+    private val testSuffixTemplate = testPrefixTemplate
+
+    private val templateId = TemplateId("templateId")
+    private val prefixTemplateId = TemplateId("prefixId")
+    private val suffixTemplateId = TemplateId("suffixId")
+    private def getTemplate(id: TemplateId): Iterable[String] =
+        if id == templateId then testTemplate
+        else if id == suffixTemplateId then testSuffixTemplate
+        else if id == prefixTemplateId then testPrefixTemplate
+        else throw IllegalStateException(s"Unknown template id $id")
+
+    private def bodyOnlyExampleContent(
+        lines: String*
+    ): ExampleContent = ExampleContent(Seq.empty, lines, Seq.empty)
+
+end ExampleSuite

--- a/yadladoc/test/src/nyub/yadladoc/YadladocSuite.scala
+++ b/yadladoc/test/src/nyub/yadladoc/YadladocSuite.scala
@@ -11,95 +11,49 @@ class YadladocSuite
     with AssertExtensions
     with SuiteExtensions:
 
-    testWithinYDocContext("One snippet"): (outputDir, configDir, workingDir) =>
-        val markdownFile = makeFile(workingDir, "README.md"):
-            l"""
+    testWithinYDocContext("Generate one file from one snippet"):
+        (outputDir, configDir, workingDir) =>
+            val markdownFile = makeFile(workingDir, "README.md"):
+                l"""
             # One snippet
             ```java ydoc.example=one.java
             class HelloYadladoc { }
             ```
             """
 
-        Yadladoc(testConfig(configDir))
-            .run(outputDir, markdownFile)
+            Yadladoc(testConfig(configDir))
+                .run(outputDir, markdownFile)
 
-        outputDir.resolve("one.java") `has content` l"""
+            outputDir.resolve("one.java") `has content` l"""
             package com.example;
             class HelloYadladoc { }
             """
 
-    testWithinYDocContext("Three snippets, first two in the same example"):
-        (outputDir: Path, configDir: Path, workingDir) =>
-            val markdownFile = makeFile(workingDir, "README.md"):
-                l"""
-            Create a list with listOf(...)
-            ```kotlin ydoc.example=kotlin-list-example.kt
-                val myList = listOf(1, 2, 3)
-            ```
-            Retrieve items with get(...)
-            ```kotlin ydoc.example=kotlin-list-example.kt
-                myList.get(0) // 1
-                myList[0] // operator alternative to get()
-            ```
-            Here is how to define a class:
-            ```kotlin ydoc.example=kotlin-class-example.kt
-                class SoCool(val coolnessLevel: Int)
-            ```
-            """
-
-            val Results(generatedFiles, errors) =
-                Yadladoc(testConfig(configDir))
-                    .run(outputDir, markdownFile)
-
-            errors `is equal to` List.empty
-
-            generatedFiles `is equal to` List(
-              GeneratedFile(
-                Some(outputDir),
-                p"kotlin-list-example.kt",
-                markdownFile
-              ),
-              GeneratedFile(
-                Some(outputDir),
-                p"kotlin-class-example.kt",
-                markdownFile
-              )
-            )
-
-            outputDir.resolve("kotlin-list-example.kt") `has content` l"""
-            package com.example
-            fun main() {
-                val myList = listOf(1, 2, 3)
-                myList.get(0) // 1
-                myList[0] // operator alternative to get()
-            }
-            """
-
-            outputDir.resolve("kotlin-class-example.kt") `has content` l"""
-            package com.example
-            fun main() {
-                class SoCool(val coolnessLevel: Int)
-            }
-            """
-
-    testWithinYDocContext("Prefix and suffix inclusion"):
+    testWithinYDocContext("Generate files from multiple snippets"):
         (outputDir, configDir, workingDir) =>
             val markdownFile = makeFile(workingDir, "README.md"):
                 l"""
-            Here is how to use an awesome library:
-            ```java ydoc.example=surround.java ydoc.prefix=import-prefix ydoc.suffix=footnote-suffix
-            new AwesomeClass().doAmazingStuff(); // Wunderbar !
+            # One snippet
+            ```java ydoc.example=one.java
+            class One { }
+            ```
+            # Another snippet
+            ```java ydoc.example=two.java
+            class Two { }
             ```
             """
+
             Yadladoc(testConfig(configDir))
                 .run(outputDir, markdownFile)
 
-            outputDir.resolve("surround.java") `has content` l"""
-        package com.example;
-        import com.awesome.lib.AwesomeClass;
-        new AwesomeClass().doAmazingStuff(); // Wunderbar !
-        // this file was written by some team at some date for a precise purpose
-        """
+            outputDir.resolve("one.java") `has content` l"""
+            package com.example;
+            class One { }
+            """
+            outputDir.resolve("two.java") `has content` l"""
+            package com.example;
+            class Two { }
+            """
 
     testWithinYDocContext("Check ok for no snippet and valid markdown"):
         (outputDir, configDir, workingDir) =>
@@ -120,15 +74,15 @@ class YadladocSuite
     ): (outputDir, configDir, workingDir) =>
         val markdownFile = makeFile(workingDir, "README.md"):
             l"""
-            ```java ydoc.example=ok.java
-            println("Hello world");
-            ```
-            """
+                ```java ydoc.example=ok.java
+                println("Hello world");
+                ```
+                """
         makeFile(outputDir, "ok.java"):
             l"""
-            package com.example;
-            println("Hello world");
-            """
+                package com.example;
+                println("Hello world");
+                """
 
         Yadladoc(testConfig(configDir))
             .check(outputDir, markdownFile) matches:
@@ -157,56 +111,6 @@ class YadladocSuite
             .errors `contains exactly in any order` List(
           CheckErrors.MissingFile(p"ko.java")
         )
-
-    testWithinYDocContext("Sanitized example name available in template"):
-        (outputDir, configDir, workingDir) =>
-            val markdownFile = makeFile(workingDir, "README.md"):
-                l"""
-            ```txt ydoc.example=a/b.txt
-            Test
-            ```
-            """
-            makeFile(
-              configDir / "includes",
-              "txt.template",
-              "${{ydoc.exampleName}}"
-            )
-            Yadladoc(testConfig(configDir))
-                .run(outputDir, markdownFile)
-
-            outputDir.resolve("a/b.txt") `has content` "a_b_txt"
-
-    testWithinYDocContext("Indexed example part name available in template"):
-        (outputDir, configDir, workingDir) =>
-            val markdownFile = makeFile(workingDir, "README.md"):
-                l"""
-            ```java ydoc.example=javaExample.java ydoc.prefix=A
-            class A {}
-            ```
-            ```java ydoc.example=javaExample.java ydoc.prefix=B
-            class B {}
-            ```
-            """
-            makeFile(
-              configDir / "includes",
-              "A.template",
-              "// ${{ydoc.subExampleName}}"
-            )
-            makeFile(
-              configDir / "includes",
-              "B.template",
-              "// ${{ydoc.subExampleName}}"
-            )
-            Yadladoc(testConfig(configDir))
-                .run(outputDir, markdownFile)
-
-            outputDir.resolve("javaExample.java") `has content` l"""
-            package com.example;
-            // javaExample_java_0
-            class A {}
-            // javaExample_java_1
-            class B {}
-            """
 
     testWithinYDocContext("Custom template per example"):
         (outputDir, configDir, workingDir) =>
@@ -266,42 +170,17 @@ class YadladocSuite
         val withYdocContext =
             FunFixture.map3(withTempDir, withTempDir, withTempDir)
         withYdocContext.test(name): (outputDir, configDir, workingDir) =>
-            makeFile(configDir / "includes", "kotlin.template")(
-              TestContext.kotlinTemplate
-            )
             makeFile(configDir / "includes", "java.template")(
-              TestContext.javaTemplate
-            )
-            makeFile(configDir / "includes", "import-prefix.template")(
-              TestContext.importPrefixTemplate
-            )
-            makeFile(configDir / "includes", "footnote-suffix.template")(
-              TestContext.footNoteSuffixTemplate
+              javaTemplate
             )
             f(outputDir, configDir, workingDir)
 
     private def testConfig(configDir: Path): Configuration =
         ConfigurationFromFile(configDir, ConfigurationConstants.DEFAULTS)
 
-    private object TestContext:
-        val kotlinTemplate = l"""
-            package com.example
-            fun main() {
-            $${{ydoc.snippet}}
-            }
-            """
-
-        val javaTemplate = l"""
-            package com.example;
-            $${{ydoc.snippet}}
-            """
-
-        val importPrefixTemplate = l"""
-            import com.awesome.lib.AwesomeClass;
-        """
-
-        val footNoteSuffixTemplate = l"""
-        // this file was written by some team at some date for a precise purpose
+    private val javaTemplate = l"""
+        package com.example;
+        $${{ydoc.snippet}}
         """
 
 end YadladocSuite


### PR DESCRIPTION
Tests in YadladocSuite test an entire yadladoc run, some were used to test specific features without needing the entire machinery

Moved these tests to more accurate suites