### PR TITLE
Fix trailing newline in read files

### DIFF
--- a/filesystem/src/nyub/filesystem/PathExtensions.scala
+++ b/filesystem/src/nyub/filesystem/PathExtensions.scala
@@ -7,6 +7,19 @@ extension (p: Path)
     def /(other: Path) = p.resolve(other)
     def /(other: String) = p.resolve(other)
     def lines: Iterable[String] =
-        val res = scala.collection.mutable.ArrayBuffer[String]()
-        Files.lines(p).forEach(res.addOne)
-        res
+        val all = Files.readString(p).splitWithDelimiters("(\r\n)|(\n)", 0)
+        DelimiterIterator(all).to(List)
+
+private class DelimiterIterator(private val delimited: Array[String])
+    extends Iterator[String]:
+    private var i = 0
+    private var addOneEmptyLine = delimited.length % 2 == 0
+    override def hasNext: Boolean = addOneEmptyLine || i < delimited.length
+    override def next(): String =
+        if i >= delimited.length && addOneEmptyLine then
+            addOneEmptyLine = false
+            ""
+        else
+            val res = delimited(i)
+            i += 2
+            res

--- a/filesystem/src/nyub/filesystem/PathExtensions.scala
+++ b/filesystem/src/nyub/filesystem/PathExtensions.scala
@@ -1,19 +1,12 @@
 package nyub.filesystem
 
 import java.nio.file.Path
-import scala.io.Source
+import java.nio.file.Files
 
 extension (p: Path)
     def /(other: Path) = p.resolve(other)
     def /(other: String) = p.resolve(other)
-    def useLines[T](f: Iterable[String] => T): T = FileIterable(p).use(f)
-
-private class FileIterable(path: Path):
-    def use[T](f: Iterable[String] => T): T =
-        val linesSource = Source.fromFile(path.toFile())
-        val iterable: Iterable[String] = new:
-            override def iterator: Iterator[String] = linesSource.getLines()
-
-        val res = f(iterable)
-        linesSource.close()
+    def lines: Iterable[String] =
+        val res = scala.collection.mutable.ArrayBuffer[String]()
+        Files.lines(p).forEach(res.addOne)
         res

--- a/filesystem/test/src/nyub/filesystem/PathExtensionsSuite.scala
+++ b/filesystem/test/src/nyub/filesystem/PathExtensionsSuite.scala
@@ -1,0 +1,10 @@
+package nyub.filesystem
+
+import nyub.assert.AssertExtensions
+import java.nio.file.Files
+
+class PathExtensionsSuite extends munit.FunSuite with AssertExtensions:
+    test("Read lines from path"):
+        val tmp = Files.createTempDirectory("testLines") / "content.txt"
+        Files.writeString(tmp, "First line\nSecond line")
+        tmp.lines `is equal to` List("First line", "Second line")

--- a/filesystem/test/src/nyub/filesystem/PathExtensionsSuite.scala
+++ b/filesystem/test/src/nyub/filesystem/PathExtensionsSuite.scala
@@ -8,3 +8,8 @@ class PathExtensionsSuite extends munit.FunSuite with AssertExtensions:
         val tmp = Files.createTempDirectory("testLines") / "content.txt"
         Files.writeString(tmp, "First line\nSecond line")
         tmp.lines `is equal to` List("First line", "Second line")
+
+    test("Return an empty string as last line for trailing newline"):
+        val tmp = Files.createTempDirectory("testLines") / "content.txt"
+        Files.writeString(tmp, "First line\n")
+        tmp.lines `is equal to` List("First line", "")

--- a/filesystem/test/src/nyub/filesystem/PathExtensionsSuite.scala
+++ b/filesystem/test/src/nyub/filesystem/PathExtensionsSuite.scala
@@ -7,9 +7,14 @@ class PathExtensionsSuite extends munit.FunSuite with AssertExtensions:
     test("Read lines from path"):
         val tmp = Files.createTempDirectory("testLines") / "content.txt"
         Files.writeString(tmp, "First line\nSecond line")
-        tmp.lines `is equal to` List("First line", "Second line")
+        tmp.lines `is equal to` Iterable("First line", "Second line")
 
     test("Return an empty string as last line for trailing newline"):
         val tmp = Files.createTempDirectory("testLines") / "content.txt"
         Files.writeString(tmp, "First line\n")
-        tmp.lines `is equal to` List("First line", "")
+        tmp.lines `is equal to` Iterable("First line", "")
+
+    test("Handle \\r\\n as single newline"):
+        val tmp = Files.createTempDirectory("testLines") / "content.txt"
+        Files.writeString(tmp, "A\r\nB")
+        tmp.lines `is equal to` Iterable("A", "B")

--- a/usage/decoration/README.md
+++ b/usage/decoration/README.md
@@ -9,4 +9,3 @@ l.get(1)
 l.contains("Picsou")
 l.get(-1)
 ```
-

--- a/usage/decoration/run.t
+++ b/usage/decoration/run.t
@@ -15,7 +15,7 @@ Along generated files, yadladoc will also "decorate" code snippets annotated wit
   l.contains("Picsou")
   l.get(-1)
   ```
-  
+
   $ cp README.md README.md.not_decorated
   $ java -jar ydoc.jar run README.md
   Generated README.md from README.md
@@ -36,6 +36,7 @@ Along generated files, yadladoc will also "decorate" code snippets annotated wit
   l.get(-1)
   //> java.lang.ArrayIndexOutOfBoundsException
   ```
+
 Cleanup
   $ cp README.md.not_decorated README.md
   $ rm README.md.not_decorated

--- a/usage/misc/.ydoc/includes/python.template
+++ b/usage/misc/.ydoc/includes/python.template
@@ -1,3 +1,2 @@
 def test_${{ydoc.exampleName}}:
 ${{ydoc.snippet}}
-

--- a/yadladoc/src/nyub/yadladoc/Yadladoc.scala
+++ b/yadladoc/src/nyub/yadladoc/Yadladoc.scala
@@ -2,7 +2,7 @@ package nyub.yadladoc
 
 import nyub.filesystem.{
     /,
-    useLines,
+    lines,
     FileSystem,
     FileTree,
     InMemoryFileSystem,
@@ -24,7 +24,7 @@ class Yadladoc(
 
     private val exampleAssembler = ExampleAssembler(
       templating,
-      id => config.templateFile(id).useLines(_.toList),
+      id => config.templateFile(id).lines,
       config.constants.snippetInjectionKey,
       config.constants.exampleNameInjectionKey,
       config.constants.subExampleNameInjectionKey,
@@ -54,7 +54,7 @@ class Yadladoc(
         markdownFile: Path,
         writeFs: FileSystem
     ): Results[Seq[GeneratedFile]] =
-        val markdownLines = markdownFile.useLines(_.toSeq)
+        val markdownLines = markdownFile.lines
         val docGen = dogGenFromMarkdown(Markdown.parse(markdownLines))
 
         val generatedExamples = docGen


### PR DESCRIPTION
Java Files.lines and derivatives skip last line if the file ends with a newline. This is confusing and erroneous, e.g. for templates ending with a newline